### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI [doctor-record-service]
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-homelab/doctor-record-service/security/code-scanning/2](https://github.com/devops-homelab/doctor-record-service/security/code-scanning/2)

To fix this issue, you should add an explicit `permissions` block to the workflow. The best practice is to set restrictive (`read-only`) permissions at the workflow root, and add more granular permissions only as needed for jobs that must perform write actions. Since both jobs in this workflow are calling external reusable workflows and there’s no evidence in the provided code that they require write access (to, e.g., issues, pull-requests, or contents), the safest minimal fix is to set `permissions: contents: read` at the workflow root—this allows the workflow to fetch repository code, but nothing more.

This will involve adding the following block immediately after the `name:` field and before `on:`, at the top of the workflow file:
```yaml
permissions:
  contents: read
```

If these jobs (or the called reusable workflows) need any additional permissions, they can be provided separately on a per-job basis. Unless you know otherwise, start with the minimal set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
